### PR TITLE
Huub tracer for CaDiCaL

### DIFF
--- a/scripts/generate-options-range-list.sh
+++ b/scripts/generate-options-range-list.sh
@@ -18,4 +18,5 @@ grep -v 'learn' | \
 grep -v 'witness' | \
 grep -v 'lrat' | \
 grep -v 'frat' | \
-grep -v 'veripb'
+grep -v 'veripb' | \
+grep -v 'huubtracer'

--- a/src/cadical.hpp
+++ b/src/cadical.hpp
@@ -802,6 +802,7 @@ public:
   //
   bool trace_proof (FILE *file, const char *name); // Write DRAT proof.
   bool trace_proof (const char *path);             // Open & write proof.
+  void begin_proof(uint64_t id);
 
   // Flushing the proof trace file eventually calls 'fflush' on the actual
   // file or pipe and thus if this function returns all the proof steps

--- a/src/huubtracer.cpp
+++ b/src/huubtracer.cpp
@@ -238,13 +238,6 @@ void HuubTracer::veripb_add_derived_clause (uint64_t id, bool redundant,
   }
 }
 
-void HuubTracer::veripb_begin_proof (uint64_t reserved_ids) {
-  file->put ("pseudo-Boolean proof version 2.0\n");
-  file->put ("f ");
-  file->put (reserved_ids);
-  file->put ("\n");
-}
-
 void HuubTracer::veripb_delete_clause (uint64_t id, bool redundant) {
   if (!redundant && checked_deletions && find_and_delete (id))
     return;
@@ -257,17 +250,6 @@ void HuubTracer::veripb_delete_clause (uint64_t id, bool redundant) {
   file->put ("\n");
 }
 
-void HuubTracer::veripb_report_status (bool unsat, uint64_t conflict_id) {
-  file->put ("output NONE\n");
-  if (unsat) {
-    file->put ("conclusion UNSAT : ");
-    file->put (conflict_id);
-    file->put (" \n");
-  } else
-    file->put ("conclusion NONE\n");
-  file->put ("end pseudo-Boolean proof\n");
-}
-
 void HuubTracer::veripb_strengthen (uint64_t id) {
   if (!checked_deletions)
     return;
@@ -277,15 +259,6 @@ void HuubTracer::veripb_strengthen (uint64_t id) {
 }
 
 /*------------------------------------------------------------------------*/
-
-void HuubTracer::begin_proof (uint64_t id) {
-  if (file->closed ())
-    return;
-  LOG ("VERIPB (HUUB) TRACER tracing start of proof with %" PRId64
-       "original clauses",
-       id);
-  veripb_begin_proof (id);
-}
 
 void HuubTracer::add_derived_clause (uint64_t id, bool redundant,
                                        const vector<int> &clause,
@@ -311,18 +284,6 @@ void HuubTracer::delete_clause (uint64_t id, bool redundant,
 #ifndef QUIET
   deleted++;
 #endif
-}
-
-void HuubTracer::report_status (int status, uint64_t conflict_id) {
-  if (file->closed ())
-    return;
-#ifdef LOGGING
-  if (conflict_id)
-    LOG ("VERIPB (HUUB) TRACER tracing finalization of proof with empty "
-         "clause[%" PRId64 "]",
-         conflict_id);
-#endif
-  veripb_report_status (status == UNSATISFIABLE, conflict_id);
 }
 
 void HuubTracer::weaken_minus (uint64_t id, const vector<int> &) {

--- a/src/huubtracer.cpp
+++ b/src/huubtracer.cpp
@@ -186,21 +186,26 @@ inline void HuubTracer::put_binary_id (uint64_t id) {
 void HuubTracer::veripb_add_derived_clause (
     uint64_t id, bool redundant, const vector<int> &clause,
     const vector<uint64_t> &chain) {
-  file->put ("pol ");
+  file->put ("label_name @c");
+  file->put (id);
+  file->put (" pol ");
   bool first = true;
   for (auto p = chain.rbegin (); p != chain.rend (); p++) {
     auto cid = *p;
     if (first) {
       first = false;
+      file->put ("@c");
       file->put (cid);
     } else {
       file->put (' ');
+      file->put ("@c");
       file->put (cid);
       file->put (" + s");
     }
   }
   file->put ("\n");
   file->put ("e ");
+  file->put ("@c");
   file->put (id);
   file->put (" : ");
   for (const auto &external_lit : clause) {
@@ -214,6 +219,7 @@ void HuubTracer::veripb_add_derived_clause (
   file->put (">= 1 ;\n");
   if (!redundant && checked_deletions) {
     file->put ("core id ");
+    file->put ("@c");
     file->put (id);
     file->put ("\n");
   }
@@ -221,7 +227,9 @@ void HuubTracer::veripb_add_derived_clause (
 
 void HuubTracer::veripb_add_derived_clause (uint64_t id, bool redundant,
                                               const vector<int> &clause) {
-  file->put ("rup ");
+  file->put ("label_name @c");
+  file->put (id);
+  file->put (" rup ");
   for (const auto &external_lit : clause) {
     file->put ("1 ");
     if (external_lit < 0)
@@ -233,6 +241,7 @@ void HuubTracer::veripb_add_derived_clause (uint64_t id, bool redundant,
   file->put (">= 1 ;\n");
   if (!redundant && checked_deletions) {
     file->put ("core id ");
+    file->put ("@c");
     file->put (id);
     file->put ("\n");
   }
@@ -246,6 +255,7 @@ void HuubTracer::veripb_delete_clause (uint64_t id, bool redundant) {
   else {
     file->put ("delc ");
   }
+  file->put ("@c");
   file->put (id);
   file->put ("\n");
 }
@@ -254,6 +264,7 @@ void HuubTracer::veripb_strengthen (uint64_t id) {
   if (!checked_deletions)
     return;
   file->put ("core id ");
+  file->put ("@c");
   file->put (id);
   file->put ("\n");
 }

--- a/src/huubtracer.cpp
+++ b/src/huubtracer.cpp
@@ -1,0 +1,391 @@
+#include "internal.hpp"
+
+namespace CaDiCaL {
+
+/*------------------------------------------------------------------------*/
+
+HuubTracer::HuubTracer (Internal *i, File *f, bool b, bool a, bool c)
+    : internal (i), file (f), with_antecedents (a), checked_deletions (c),
+      num_clauses (0), size_clauses (0), clauses (0), last_hash (0),
+      last_id (0), last_clause (0)
+#ifndef QUIET
+      ,
+      added (0), deleted (0)
+#endif
+{
+  (void) internal;
+
+  // Initialize random number table for hash function.
+  //
+  Random random (42);
+  for (unsigned n = 0; n < num_nonces; n++) {
+    uint64_t nonce = random.next ();
+    if (!(nonce & 1))
+      nonce++;
+    assert (nonce), assert (nonce & 1);
+    nonces[n] = nonce;
+  }
+#ifndef NDEBUG
+  binary = b;
+#else
+  (void) b;
+#endif
+}
+
+void HuubTracer::connect_internal (Internal *i) {
+  internal = i;
+  file->connect_internal (internal);
+  LOG ("VERIPB TRACER connected to internal");
+}
+
+HuubTracer::~HuubTracer () {
+  LOG ("VERIPB TRACER delete");
+  delete file;
+  for (size_t i = 0; i < size_clauses; i++)
+    for (HashId *c = clauses[i], *next; c; c = next)
+      next = c->next, delete_clause (c);
+  delete[] clauses;
+}
+
+/*------------------------------------------------------------------------*/
+
+void HuubTracer::enlarge_clauses () {
+  assert (num_clauses == size_clauses);
+  const uint64_t new_size_clauses = size_clauses ? 2 * size_clauses : 1;
+  LOG ("VeriPB Tracer enlarging clauses from %" PRIu64 " to %" PRIu64,
+       (uint64_t) size_clauses, (uint64_t) new_size_clauses);
+  HashId **new_clauses;
+  new_clauses = new HashId *[new_size_clauses];
+  clear_n (new_clauses, new_size_clauses);
+  for (uint64_t i = 0; i < size_clauses; i++) {
+    for (HashId *c = clauses[i], *next; c; c = next) {
+      next = c->next;
+      const uint64_t h = reduce_hash (c->hash, new_size_clauses);
+      c->next = new_clauses[h];
+      new_clauses[h] = c;
+    }
+  }
+  delete[] clauses;
+  clauses = new_clauses;
+  size_clauses = new_size_clauses;
+}
+
+HashId *HuubTracer::new_clause () {
+  HashId *res = new HashId ();
+  res->next = 0;
+  res->hash = last_hash;
+  res->id = last_id;
+  last_clause = res;
+  num_clauses++;
+  return res;
+}
+
+void HuubTracer::delete_clause (HashId *c) {
+  assert (c);
+  num_clauses--;
+  delete c;
+}
+
+uint64_t HuubTracer::reduce_hash (uint64_t hash, uint64_t size) {
+  assert (size > 0);
+  unsigned shift = 32;
+  uint64_t res = hash;
+  while ((((uint64_t) 1) << shift) > size) {
+    res ^= res >> shift;
+    shift >>= 1;
+  }
+  res &= size - 1;
+  assert (res < size);
+  return res;
+}
+
+uint64_t HuubTracer::compute_hash (const uint64_t id) {
+  assert (id > 0);
+  unsigned j = id % num_nonces;             // Dont know if this is a good
+  uint64_t tmp = nonces[j] * (uint64_t) id; // hash funktion or even better
+  return last_hash = tmp;                   // than just using id.
+}
+
+bool HuubTracer::find_and_delete (const uint64_t id) {
+  if (!num_clauses)
+    return false;
+  /*
+  if (last_clause && last_clause->id == id) {
+    const uint64_t h = reduce_hash (last_clause->hash, size_clauses);
+    clauses[h] = last_clause->next;
+    delete last_clause;
+    return true;
+  }
+  */
+  HashId **res = 0, *c;
+  const uint64_t hash = compute_hash (id);
+  const uint64_t h = reduce_hash (hash, size_clauses);
+  for (res = clauses + h; (c = *res); res = &c->next) {
+    if (c->hash == hash && c->id == id) {
+      break;
+    }
+    if (!c->next)
+      return false;
+  }
+  if (!c)
+    return false;
+  assert (c && res);
+  *res = c->next;
+  delete_clause (c);
+  return true;
+}
+
+void HuubTracer::insert () {
+  if (num_clauses == size_clauses)
+    enlarge_clauses ();
+  const uint64_t h = reduce_hash (compute_hash (last_id), size_clauses);
+  HashId *c = new_clause ();
+  c->next = clauses[h];
+  clauses[h] = c;
+}
+
+/*------------------------------------------------------------------------*/
+
+inline void HuubTracer::put_binary_zero () {
+  assert (binary);
+  assert (file);
+  file->put ((unsigned char) 0);
+}
+
+inline void HuubTracer::put_binary_lit (int lit) {
+  assert (binary);
+  assert (file);
+  assert (lit != INT_MIN);
+  unsigned x = 2 * abs (lit) + (lit < 0);
+  unsigned char ch;
+  while (x & ~0x7f) {
+    ch = (x & 0x7f) | 0x80;
+    file->put (ch);
+    x >>= 7;
+  }
+  ch = x;
+  file->put (ch);
+}
+
+inline void HuubTracer::put_binary_id (uint64_t id) {
+  assert (binary);
+  assert (file);
+  uint64_t x = id;
+  unsigned char ch;
+  while (x & ~0x7f) {
+    ch = (x & 0x7f) | 0x80;
+    file->put (ch);
+    x >>= 7;
+  }
+  ch = x;
+  file->put (ch);
+}
+
+/*------------------------------------------------------------------------*/
+
+void HuubTracer::veripb_add_derived_clause (
+    uint64_t id, bool redundant, const vector<int> &clause,
+    const vector<uint64_t> &chain) {
+  file->put ("pol ");
+  bool first = true;
+  for (auto p = chain.rbegin (); p != chain.rend (); p++) {
+    auto cid = *p;
+    if (first) {
+      first = false;
+      file->put (cid);
+    } else {
+      file->put (' ');
+      file->put (cid);
+      file->put (" + s");
+    }
+  }
+  file->put ("\n");
+  file->put ("e ");
+  file->put (id);
+  file->put (" : ");
+  for (const auto &external_lit : clause) {
+    file->put ("1 ");
+    if (external_lit < 0)
+      file->put ('~');
+    file->put ('x');
+    file->put (abs (external_lit));
+    file->put (' ');
+  }
+  file->put (">= 1 ;\n");
+  if (!redundant && checked_deletions) {
+    file->put ("core id ");
+    file->put (id);
+    file->put ("\n");
+  }
+}
+
+void HuubTracer::veripb_add_derived_clause (uint64_t id, bool redundant,
+                                              const vector<int> &clause) {
+  file->put ("rup ");
+  for (const auto &external_lit : clause) {
+    file->put ("1 ");
+    if (external_lit < 0)
+      file->put ('~');
+    file->put ('x');
+    file->put (abs (external_lit));
+    file->put (' ');
+  }
+  file->put (">= 1 ;\n");
+  if (!redundant && checked_deletions) {
+    file->put ("core id ");
+    file->put (id);
+    file->put ("\n");
+  }
+}
+
+void HuubTracer::veripb_begin_proof (uint64_t reserved_ids) {
+  file->put ("pseudo-Boolean proof version 2.0\n");
+  file->put ("f ");
+  file->put (reserved_ids);
+  file->put ("\n");
+}
+
+void HuubTracer::veripb_delete_clause (uint64_t id, bool redundant) {
+  if (!redundant && checked_deletions && find_and_delete (id))
+    return;
+  if (redundant || !checked_deletions)
+    file->put ("del id ");
+  else {
+    file->put ("delc ");
+  }
+  file->put (id);
+  file->put ("\n");
+}
+
+void HuubTracer::veripb_report_status (bool unsat, uint64_t conflict_id) {
+  file->put ("output NONE\n");
+  if (unsat) {
+    file->put ("conclusion UNSAT : ");
+    file->put (conflict_id);
+    file->put (" \n");
+  } else
+    file->put ("conclusion NONE\n");
+  file->put ("end pseudo-Boolean proof\n");
+}
+
+void HuubTracer::veripb_strengthen (uint64_t id) {
+  if (!checked_deletions)
+    return;
+  file->put ("core id ");
+  file->put (id);
+  file->put ("\n");
+}
+
+/*------------------------------------------------------------------------*/
+
+void HuubTracer::begin_proof (uint64_t id) {
+  if (file->closed ())
+    return;
+  LOG ("VERIPB TRACER tracing start of proof with %" PRId64
+       "original clauses",
+       id);
+  veripb_begin_proof (id);
+}
+
+void HuubTracer::add_derived_clause (uint64_t id, bool redundant,
+                                       const vector<int> &clause,
+                                       const vector<uint64_t> &chain) {
+  if (file->closed ())
+    return;
+  LOG ("VERIPB TRACER tracing addition of derived clause[%" PRId64 "]", id);
+  if (with_antecedents)
+    veripb_add_derived_clause (id, redundant, clause, chain);
+  else
+    veripb_add_derived_clause (id, redundant, clause);
+#ifndef QUIET
+  added++;
+#endif
+}
+
+void HuubTracer::delete_clause (uint64_t id, bool redundant,
+                                  const vector<int> &) {
+  if (file->closed ())
+    return;
+  LOG ("VERIPB TRACER tracing deletion of clause[%" PRId64 "]", id);
+  veripb_delete_clause (id, redundant);
+#ifndef QUIET
+  deleted++;
+#endif
+}
+
+void HuubTracer::report_status (int status, uint64_t conflict_id) {
+  if (file->closed ())
+    return;
+#ifdef LOGGING
+  if (conflict_id)
+    LOG ("VERIPB TRACER tracing finalization of proof with empty "
+         "clause[%" PRId64 "]",
+         conflict_id);
+#endif
+  veripb_report_status (status == UNSATISFIABLE, conflict_id);
+}
+
+void HuubTracer::weaken_minus (uint64_t id, const vector<int> &) {
+  if (!checked_deletions)
+    return;
+  if (file->closed ())
+    return;
+  LOG ("VERIPB TRACER tracing weaken minus of clause[%" PRId64 "]", id);
+  last_id = id;
+  insert ();
+}
+
+void HuubTracer::strengthen (uint64_t id) {
+  if (file->closed ())
+    return;
+  LOG ("VERIPB TRACER tracing strengthen of clause[%" PRId64 "]", id);
+  veripb_strengthen (id);
+}
+
+/*------------------------------------------------------------------------*/
+
+bool HuubTracer::closed () { return file->closed (); }
+
+#ifndef QUIET
+
+void HuubTracer::print_statistics () {
+  // TODO complete
+  uint64_t bytes = file->bytes ();
+  uint64_t total = added + deleted;
+  MSG ("VeriPB %" PRId64 " added clauses %.2f%%", added,
+       percent (added, total));
+  MSG ("VeriPB %" PRId64 " deleted clauses %.2f%%", deleted,
+       percent (deleted, total));
+  MSG ("VeriPB %" PRId64 " bytes (%.2f MB)", bytes,
+       bytes / (double) (1 << 20));
+}
+
+#endif
+
+void HuubTracer::close (bool print) {
+  assert (!closed ());
+  file->close ();
+#ifndef QUIET
+  if (print) {
+    MSG ("VeriPB proof file '%s' closed", file->name ());
+    print_statistics ();
+  }
+#else
+  (void) print;
+#endif
+}
+
+void HuubTracer::flush (bool print) {
+  assert (!closed ());
+  file->flush ();
+#ifndef QUIET
+  if (print) {
+    MSG ("VeriPB proof file '%s' flushed", file->name ());
+    print_statistics ();
+  }
+#else
+  (void) print;
+#endif
+}
+
+} // namespace CaDiCaL

--- a/src/huubtracer.cpp
+++ b/src/huubtracer.cpp
@@ -35,11 +35,11 @@ HuubTracer::HuubTracer (Internal *i, File *f, bool b, bool a, bool c)
 void HuubTracer::connect_internal (Internal *i) {
   internal = i;
   file->connect_internal (internal);
-  LOG ("VERIPB TRACER connected to internal");
+  LOG ("VERIPB (HUUB) TRACER connected to internal");
 }
 
 HuubTracer::~HuubTracer () {
-  LOG ("VERIPB TRACER delete");
+  LOG ("VERIPB (HUUB) TRACER delete");
   delete file;
   for (size_t i = 0; i < size_clauses; i++)
     for (HashId *c = clauses[i], *next; c; c = next)
@@ -52,7 +52,7 @@ HuubTracer::~HuubTracer () {
 void HuubTracer::enlarge_clauses () {
   assert (num_clauses == size_clauses);
   const uint64_t new_size_clauses = size_clauses ? 2 * size_clauses : 1;
-  LOG ("VeriPB Tracer enlarging clauses from %" PRIu64 " to %" PRIu64,
+  LOG ("VeriPB (HUUB) Tracer enlarging clauses from %" PRIu64 " to %" PRIu64,
        (uint64_t) size_clauses, (uint64_t) new_size_clauses);
   HashId **new_clauses;
   new_clauses = new HashId *[new_size_clauses];
@@ -281,7 +281,7 @@ void HuubTracer::veripb_strengthen (uint64_t id) {
 void HuubTracer::begin_proof (uint64_t id) {
   if (file->closed ())
     return;
-  LOG ("VERIPB TRACER tracing start of proof with %" PRId64
+  LOG ("VERIPB (HUUB) TRACER tracing start of proof with %" PRId64
        "original clauses",
        id);
   veripb_begin_proof (id);
@@ -292,7 +292,7 @@ void HuubTracer::add_derived_clause (uint64_t id, bool redundant,
                                        const vector<uint64_t> &chain) {
   if (file->closed ())
     return;
-  LOG ("VERIPB TRACER tracing addition of derived clause[%" PRId64 "]", id);
+  LOG ("VERIPB (HUUB) TRACER tracing addition of derived clause[%" PRId64 "]", id);
   if (with_antecedents)
     veripb_add_derived_clause (id, redundant, clause, chain);
   else
@@ -306,7 +306,7 @@ void HuubTracer::delete_clause (uint64_t id, bool redundant,
                                   const vector<int> &) {
   if (file->closed ())
     return;
-  LOG ("VERIPB TRACER tracing deletion of clause[%" PRId64 "]", id);
+  LOG ("VERIPB (HUUB) TRACER tracing deletion of clause[%" PRId64 "]", id);
   veripb_delete_clause (id, redundant);
 #ifndef QUIET
   deleted++;
@@ -318,7 +318,7 @@ void HuubTracer::report_status (int status, uint64_t conflict_id) {
     return;
 #ifdef LOGGING
   if (conflict_id)
-    LOG ("VERIPB TRACER tracing finalization of proof with empty "
+    LOG ("VERIPB (HUUB) TRACER tracing finalization of proof with empty "
          "clause[%" PRId64 "]",
          conflict_id);
 #endif
@@ -330,7 +330,7 @@ void HuubTracer::weaken_minus (uint64_t id, const vector<int> &) {
     return;
   if (file->closed ())
     return;
-  LOG ("VERIPB TRACER tracing weaken minus of clause[%" PRId64 "]", id);
+  LOG ("VERIPB (HUUB) TRACER tracing weaken minus of clause[%" PRId64 "]", id);
   last_id = id;
   insert ();
 }
@@ -338,7 +338,7 @@ void HuubTracer::weaken_minus (uint64_t id, const vector<int> &) {
 void HuubTracer::strengthen (uint64_t id) {
   if (file->closed ())
     return;
-  LOG ("VERIPB TRACER tracing strengthen of clause[%" PRId64 "]", id);
+  LOG ("VERIPB (HUUB) TRACER tracing strengthen of clause[%" PRId64 "]", id);
   veripb_strengthen (id);
 }
 
@@ -352,11 +352,11 @@ void HuubTracer::print_statistics () {
   // TODO complete
   uint64_t bytes = file->bytes ();
   uint64_t total = added + deleted;
-  MSG ("VeriPB %" PRId64 " added clauses %.2f%%", added,
+  MSG ("VeriPB (HUUB) %" PRId64 " added clauses %.2f%%", added,
        percent (added, total));
-  MSG ("VeriPB %" PRId64 " deleted clauses %.2f%%", deleted,
+  MSG ("VeriPB (HUUB) %" PRId64 " deleted clauses %.2f%%", deleted,
        percent (deleted, total));
-  MSG ("VeriPB %" PRId64 " bytes (%.2f MB)", bytes,
+  MSG ("VeriPB (HUUB) %" PRId64 " bytes (%.2f MB)", bytes,
        bytes / (double) (1 << 20));
 }
 
@@ -367,7 +367,7 @@ void HuubTracer::close (bool print) {
   file->close ();
 #ifndef QUIET
   if (print) {
-    MSG ("VeriPB proof file '%s' closed", file->name ());
+    MSG ("VeriPB (HUUB) proof file '%s' closed", file->name ());
     print_statistics ();
   }
 #else
@@ -380,7 +380,7 @@ void HuubTracer::flush (bool print) {
   file->flush ();
 #ifndef QUIET
   if (print) {
-    MSG ("VeriPB proof file '%s' flushed", file->name ());
+    MSG ("VeriPB (HUUB) proof file '%s' flushed", file->name ());
     print_statistics ();
   }
 #else

--- a/src/huubtracer.hpp
+++ b/src/huubtracer.hpp
@@ -69,7 +69,7 @@ public:
   ~HuubTracer ();
 
   void connect_internal (Internal *i) override;
-  void begin_proof (uint64_t) override;
+  void begin_proof (uint64_t) override {} // skip (leave to huub)
 
   void add_original_clause (uint64_t, bool, const vector<int> &,
                             bool = false) override {} // skip
@@ -80,7 +80,7 @@ public:
   void delete_clause (uint64_t, bool, const vector<int> &) override;
   void finalize_clause (uint64_t, const vector<int> &) override {} // skip
 
-  void report_status (int, uint64_t) override;
+  void report_status (int, uint64_t) override {} // skip (leave to huub)
 
   void weaken_minus (uint64_t, const vector<int> &) override;
   void strengthen (uint64_t) override;

--- a/src/huubtracer.hpp
+++ b/src/huubtracer.hpp
@@ -8,7 +8,6 @@ namespace CaDiCaL {
 struct HashId; 
 
 class HuubTracer : public FileTracer {
-
   Internal *internal;
   File *file;
 #ifndef NDEBUG
@@ -57,7 +56,7 @@ class HuubTracer : public FileTracer {
                                   const vector<int> &clause,
                                   const vector<uint64_t> &chain);
   void veripb_add_derived_clause (uint64_t, bool redundant,
-                                  const vector<int> &clause);
+                                  const vector<int> &clause, bool asserted);
   void veripb_begin_proof (uint64_t reserved_ids);
   void veripb_delete_clause (uint64_t id, bool redundant);
   void veripb_report_status (bool unsat, uint64_t conflict_id);
@@ -69,10 +68,10 @@ public:
   ~HuubTracer ();
 
   void connect_internal (Internal *i) override;
-  void begin_proof (uint64_t) override {} // skip (leave to huub)
+  void begin_proof (uint64_t) override;
 
   void add_original_clause (uint64_t, bool, const vector<int> &,
-                            bool = false) override {} // skip
+                            bool = false) override;
 
   void add_derived_clause (uint64_t, bool, const vector<int> &,
                            const vector<uint64_t> &) override;
@@ -80,11 +79,10 @@ public:
   void delete_clause (uint64_t, bool, const vector<int> &) override;
   void finalize_clause (uint64_t, const vector<int> &) override {} // skip
 
-  void report_status (int, uint64_t) override {} // skip (leave to huub)
+  void report_status (int, uint64_t) override {} // skip
 
   void weaken_minus (uint64_t, const vector<int> &) override;
   void strengthen (uint64_t) override;
-
 #ifndef QUIET
   void print_statistics ();
 #endif

--- a/src/huubtracer.hpp
+++ b/src/huubtracer.hpp
@@ -1,0 +1,98 @@
+#ifndef _huubtracer_h_INCLUDED
+#define _huubtracer_h_INCLUDED
+
+class FileTracer;
+
+namespace CaDiCaL {
+
+struct HashId; 
+
+class HuubTracer : public FileTracer {
+
+  Internal *internal;
+  File *file;
+#ifndef NDEBUG
+  bool binary;
+#endif
+  bool with_antecedents;
+  bool checked_deletions;
+
+  // hash table for checked deletions
+  //
+  uint64_t num_clauses;  // number of clauses in hash table
+  uint64_t size_clauses; // size of clause hash table
+  HashId **clauses;      // hash table of clauses
+
+  static const unsigned num_nonces = 4;
+
+  uint64_t nonces[num_nonces]; // random numbers for hashing
+  uint64_t last_hash;          // last computed hash value of clause
+  uint64_t last_id;            // id of the last added clause
+  HashId *last_clause;
+  uint64_t compute_hash (uint64_t); // compute and save hash value of clause
+
+  HashId *new_clause ();
+  void delete_clause (HashId *);
+
+  // Reduce hash value to the actual size.
+  //
+  static uint64_t reduce_hash (uint64_t hash, uint64_t size);
+
+  void enlarge_clauses (); // enlarge hash table for clauses
+  void insert ();          // insert clause in hash table
+  bool
+  find_and_delete (const uint64_t); // find clause position in hash table
+
+#ifndef QUIET
+  int64_t added, deleted;
+#endif
+  vector<uint64_t> delete_ids;
+
+  void put_binary_zero ();
+  void put_binary_lit (int external_lit);
+  void put_binary_id (uint64_t id);
+
+  // support veriPB
+  void veripb_add_derived_clause (uint64_t, bool redundant,
+                                  const vector<int> &clause,
+                                  const vector<uint64_t> &chain);
+  void veripb_add_derived_clause (uint64_t, bool redundant,
+                                  const vector<int> &clause);
+  void veripb_begin_proof (uint64_t reserved_ids);
+  void veripb_delete_clause (uint64_t id, bool redundant);
+  void veripb_report_status (bool unsat, uint64_t conflict_id);
+  void veripb_strengthen (uint64_t);
+
+public:
+  // own and delete 'file'
+  HuubTracer (Internal *, File *file, bool, bool, bool);
+  ~HuubTracer ();
+
+  void connect_internal (Internal *i) override;
+  void begin_proof (uint64_t) override;
+
+  void add_original_clause (uint64_t, bool, const vector<int> &,
+                            bool = false) override {} // skip
+
+  void add_derived_clause (uint64_t, bool, const vector<int> &,
+                           const vector<uint64_t> &) override;
+
+  void delete_clause (uint64_t, bool, const vector<int> &) override;
+  void finalize_clause (uint64_t, const vector<int> &) override {} // skip
+
+  void report_status (int, uint64_t) override;
+
+  void weaken_minus (uint64_t, const vector<int> &) override;
+  void strengthen (uint64_t) override;
+
+#ifndef QUIET
+  void print_statistics ();
+#endif
+  bool closed () override;
+  void close (bool) override;
+  void flush (bool) override;
+};
+
+} // namespace CaDiCaL
+
+#endif

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -1365,8 +1365,7 @@ struct Internal {
   void close_trace (bool stats = false); // Stop proof tracing.
   void flush_trace (bool stats = false); // Flush proof trace file.
   void trace (File *);                   // Start write proof file.
-  void check ();                         // Enable online proof checking.
-
+  void check ();                         // Enable online proof checking.    
   void connect_proof_tracer (Tracer *tracer, bool antecedents,
                              bool finalize_clauses = false);
   void connect_proof_tracer (InternalTracer *tracer, bool antecedents,
@@ -1380,6 +1379,10 @@ struct Internal {
   bool disconnect_proof_tracer (FileTracer *tracer);
   void conclude_unsat ();
   void reset_concluded ();
+  
+  // Manually begin the proof
+  // (Added for Huub)
+  void begin_proof (uint64_t);   
 
   // Dump to '<stdout>' as DIMACS for debugging.
   //

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -66,6 +66,7 @@ extern "C" {
 #include "format.hpp"
 #include "frattracer.hpp"
 #include "heap.hpp"
+#include "huubtracer.hpp"
 #include "idruptracer.hpp"
 #include "instantiate.hpp"
 #include "internal.hpp"

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -100,6 +100,7 @@ OPTION( flushfactor,       3,  1,1e3,0,0,1, "interval increase") \
 OPTION( flushint,        1e5,  1,2e9,0,0,1, "initial limit") \
 OPTION( forcephase,        0,  0,  1,0,0,1, "always use initial phase") \
 OPTION( frat,              0,  0,  2,0,0,1, "1=frat(lrat), 2=frat(drat)") \
+OPTION( huubtracer,            0,  0,  4,0,0,1, "odd=checkdeletions, > 2=drat") \
 OPTION( idrup,             0,  0,  1,0,0,1, "incremental proof format") \
 OPTION( ilb,               0,  0,  1,0,0,1, "ILB (incremental lazy backtrack)") \
 OPTION( ilbassumptions,    0,  0,  1,0,0,1, "trail reuse for assumptions (ILB-like)") \

--- a/src/proof.cpp
+++ b/src/proof.cpp
@@ -210,6 +210,13 @@ void Internal::flush_trace (bool print) {
     tracer->flush (print);
 }
 
+// Manually begin the proof (with the specified reserved id count)
+// (Added for Huub logging specifically), where id will always be 0
+void Internal::begin_proof (uint64_t id) {
+  if (proof)
+    proof->begin_proof(id);
+}
+
 /*------------------------------------------------------------------------*/
 
 Proof::Proof (Internal *s) : internal (s), lratbuilder (0) {

--- a/src/proof.cpp
+++ b/src/proof.cpp
@@ -130,7 +130,14 @@ void Proof::disconnect (Tracer *t) {
 // Enable proof tracing.
 
 void Internal::trace (File *file) {
-  if (opts.veripb) {
+  if (opts.huubtracer) {
+    LOG ("PROOF connecting VeriPB (HUUB) tracer");
+    bool antecedents = opts.huubtracer == 1 || opts.huubtracer == 2;
+    bool deletions = opts.huubtracer == 2 || opts.huubtracer == 4;
+    FileTracer *ft =
+        new HuubTracer (this, file, opts.binary, antecedents, deletions);
+    connect_proof_tracer (ft, antecedents);
+  } else if (opts.veripb) {
     LOG ("PROOF connecting VeriPB tracer");
     bool antecedents = opts.veripb == 1 || opts.veripb == 2;
     bool deletions = opts.veripb == 2 || opts.veripb == 4;

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -1209,6 +1209,11 @@ void Solver::close_proof_trace (bool print_statistics_unless_quiet) {
   LOG_API_CALL_END ("close_proof_trace");
 }
 
+void Solver::begin_proof (uint64_t id) {
+  TRACE ("begin_proof", id);
+  internal->begin_proof (id);
+}
+
 /*------------------------------------------------------------------------*/
 
 void Solver::connect_proof_tracer (Tracer *tracer, bool antecedents,


### PR DESCRIPTION
The current `veripbtracer` has some problems if we want to use it out of the box as part of proof logging for Huub (see huub-solver/huub#171).
- It uses internal CaDiCaL ids for constraints which don't reference anything (since there is no DIMACS input) and will be difficult to extend with subderivations later.
- It concludes the proof multiple times due to the multiple solve calls
- It doesn't by default log the external clauses added by Huub.

This PR is to create a new tracer `huubtracer` that mostly functions the same as `veriptracer` except it uses labeled constraint IDs rather than raw IDs, logs external clauses as assertions, and does not conclude the proof multiple times. 
@